### PR TITLE
SREP-923: Move ebs-stuck-volume exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Rendered templates
+deploy/025_sourcecode.yaml
+deploy/030_secrets.yaml
+deploy/040_deployment.yaml
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ RESOURCELIST := servicemonitor/stuck-ebs-vols service/stuck-ebs-vols deployment/
 all: deploy/025_sourcecode.yaml deploy/030_secrets.yaml deploy/040_deployment.yaml
 
 .PHONY: check-env
-
 check-env:
 ifndef CLUSTERID
 	$(error Please set CLUSTERID)

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ clean:
 	rm -f deploy/025_sourcecode.yaml deploy/030_secrets.yaml deploy/040_deployment.yaml
 
 .PHONY: filelist
-filelist:
+filelist: all
 	@ls -1 deploy/*.y*ml
 
 .PHONE: resourcelist

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ deploy/025_sourcecode.yaml: $(SOURCEFILES)
 	kubectl -n openshift-monitoring create configmap stuck-ebs-vols-code --dry-run=true -o yaml $$files 1> deploy/025_sourcecode.yaml
 
 deploy/040_deployment.yaml: check-env
-	@echo "Creaging $(@)" ; \
+	@echo "Creating $(@)" ; \
 	sed \
 		-e "s/\$$IMAGE_VERSION/$(IMAGE_VERSION)/g" \
 		-e "s/\$$CLUSTERID/$$CLUSTERID/g" \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,77 @@
+SHELL := /bin/bash
+
+# All of the source files which compose the monitor. 
+# Important note: No directory structure will be maintained
+SOURCEFILES ?= monitor/main.py
+
+IMAGE_VERSION ?= stable
+RESOURCELIST := servicemonitor/stuck-ebs-vols service/stuck-ebs-vols deployment/stuck-ebs-vols secret/stuck-ebs-vols-credentials-volume configmap/stuck-ebs-vols-code rolebinding/sre-stuck-ebs-vols serviceaccount/sre-stuck-ebs-vols
+
+all: deploy/025_sourcecode.yaml deploy/030_secrets.yaml deploy/040_deployment.yaml
+
+.PHONY: check-env
+
+check-env:
+ifndef CLUSTERID
+	$(error Please set CLUSTERID)
+endif
+ifndef AWS_REGION
+	$(error Please set AWS_REGION)
+endif
+ifndef AWS_SECRET_ACCESS_KEY
+	$(error Please set AWS_SECRET_ACCESS_KEY)
+endif
+ifndef AWS_ACCESS_KEY_ID
+	$(error Please set AWS_ACCESS_KEY_ID)
+endif
+
+deploy/025_sourcecode.yaml: $(SOURCEFILES)
+	@echo "Creating $(@)" ; \
+	for sfile in $(SOURCEFILES); do \
+		files="--from-file=$$sfile $$files" ; \
+	done ; \
+	kubectl -n openshift-monitoring create configmap stuck-ebs-vols-code --dry-run=true -o yaml $$files 1> deploy/025_sourcecode.yaml
+
+deploy/040_deployment.yaml: check-env
+	@echo "Creaging $(@)" ; \
+	sed \
+		-e "s/\$$IMAGE_VERSION/$(IMAGE_VERSION)/g" \
+		-e "s/\$$CLUSTERID/$$CLUSTERID/g" \
+	resources/040_deployment.yaml.tmpl 1> deploy/040_deployment.yaml
+
+deploy/030_secrets.yaml: check-env
+	@echo "Creating $(@)" ; \
+	umask 077 ; \
+	tmpdir=$(shell mktemp -d $(self)) ; \
+	if [[ ! -d $$tmpdir ]]; then \
+		echo "Not able to create temp dir for secrets. Giving up" ;\
+		exit 1 ;\
+	fi ;\
+	echo "  Temporary dir=$$tmpdir" ; \
+	sed \
+		-e "s/\$$AWS_ACCESS_KEY_ID/$$AWS_ACCESS_KEY_ID/g" \
+		-e "s/\$$AWS_SECRET_ACCESS_KEY/$$AWS_SECRET_ACCESS_KEY/g" \
+	resources/secrets-credentials.tmpl 1> $$tmpdir/credentials ; \
+	sed \
+		-e "s/\$$AWS_REGION/$$AWS_REGION/g" \
+	resources/secrets-config.tmpl 1> $$tmpdir/config ; \
+	kubectl \
+		-n openshift-monitoring \
+		create secret generic stuck-ebs-vols-credentials-volume \
+		--dry-run=true -o yaml \
+		--from-file=$$tmpdir/credentials --from-file=$$tmpdir/config \
+		1> deploy/030_secrets.yaml ; \
+	echo "  Cleaning temp dir ($$tmpdir)" ; \
+	rm -rf $$tmpdir
+
+.PHONY: clean
+clean:
+	rm -f deploy/025_sourcecode.yaml deploy/030_secrets.yaml deploy/040_deployment.yaml
+
+.PHONY: filelist
+filelist:
+	@ls -1 deploy/*.y*ml
+
+.PHONE: resourcelist
+resourcelist:
+	@echo $(RESOURCELIST)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,79 @@
+# Stuck EBS Volume Exporter
+
+This monitor is designed to expose a HTTP Service endpoint that Prometheus will use to gather information about the state of the cluster's attached EBS volumes.
+
+## Prometheus Output
+
+A volume may be in one of these states `attaching`, `attached`, `detaching`, `detached` and is thus reported, for example, in one time slice:
+
+        ebs_volume_state{vol_id="vol-d34db33f",clusterid="testcluster",vol_state="attaching"} 1.0
+        ebs_volume_state{vol_id="vol-d34db33f",clusterid="testcluster",vol_state="attached"} 0.0
+        ebs_volume_state{vol_id="vol-d34db33f",clusterid="testcluster",vol_state="detaching"} 0.0
+        ebs_volume_state{vol_id="vol-d34db33f",clusterid="testcluster",vol_state="detached"} 0.0
+
+The next time slice may be
+
+        ebs_volume_state{vol_id="vol-d34db33f",clusterid="testcluster",vol_state="attaching"} 0.0
+        ebs_volume_state{vol_id="vol-d34db33f",clusterid="testcluster",vol_state="attached"} 1.0
+        ebs_volume_state{vol_id="vol-d34db33f",clusterid="testcluster",vol_state="detaching"} 0.0
+        ebs_volume_state{vol_id="vol-d34db33f",clusterid="testcluster",vol_state="detached"} 0.0
+
+And the next might be
+
+        ebs_volume_state{vol_id="vol-d34db33f",clusterid="testcluster",vol_state="attaching"} 0.0
+        ebs_volume_state{vol_id="vol-d34db33f",clusterid="testcluster",vol_state="attached"} 0.0
+        ebs_volume_state{vol_id="vol-d34db33f",clusterid="testcluster",vol_state="detaching"} 0.0
+        ebs_volume_state{vol_id="vol-d34db33f",clusterid="testcluster",vol_state="detached"} 1.0
+
+Here, we can see the transition from attaching to attached to detached. Note that the the state record may have missed the `detaching` state transition on the way to `detached` due to the polling interval.
+
+(Note: These are sample outputs)
+
+### PromQL - What's Stuck
+
+When the attaching or detaching state is high (`1.0`) for whichever interval we care about we can consider the volume `vol_id` to be "stuck."
+
+The query `min_over_time(ebs_volume_state{ebs_volume_state="attaching"}[5m]) == 1` can be used to identify volumes which have only been in the `attaching` state for the past five minutes. The `[5m]` time interval can be changed for other timeframes, perhaps causing a warning at 5 minutes and a critical alert at 10 minutes.
+
+## Required IAM Roles
+
+This service requires these read-only IAM roles:
+
+* `ec2:DescribeInstances`
+
+## Installation Process
+
+Installation of the exporter is a multi-step process. Step one is to use the provided Makefile to render various templates into OpenShift YAML manifests.
+
+### Rendering Templates with Make
+
+A total of four variables must be provided with make:
+
+* `AWS_REGION` - The region to make AWS API calls against
+* `AWS_ACCESS_KEY_ID` - The AWS access key ID
+* `AWS_SECRET_ACCESS_KEY` - The AWS secret access key
+* `CLUSTERID` - The identifier of the cluster. Only EBS volumes tagged `clusterid: $CLUSTERID` will be checked
+
+Optionally, a different image version can be provided with the `IMAGE_VERSION` variable. The defalt is `stable`.
+
+Currently these are provided as environment variables to `make`.
+
+`make all` will render these manifests:
+
+* `deploy/025_sourcecode.yaml`
+* `deploy/030_secrets.yaml`
+* `deploy/040_deployment.yaml`
+
+Once these have been created the collection of manifests can be applied in the usual fashion (such as `oc apply -f`).
+
+### Additional Make Targets
+
+The Makefile includes three helpful targets:
+
+* `clean` - Delete any of the rendered manifest files which the Makefile renders
+* `filelist` - Echos to the terminal a list of all the YAML files in the `deploy` directory
+* `resourcelist` - Echos to the terminal a list of OpenShift/Kubernetes objects created by the manifests in the `deploy` directory, which may be useful for those wishing to delete the installation of this monitor.
+
+### Prometheus Rules
+
+Rules are provided by the [openshift/managed-cluster-config](https://github.com/openshift/managed-cluster-config) repository.

--- a/deploy/010_serviceaccount-rolebinding.yaml
+++ b/deploy/010_serviceaccount-rolebinding.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sre-stuck-ebs-vols
+  namespace: openshift-monitoring
+---
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  name: sre-stuck-ebs-vols
+  namespace: openshift-monitoring
+roleRef:
+  name: edit
+subjects:
+- kind: ServiceAccount
+  name: sre-stuck-ebs-vols
+  namespace: openshift-monitoring
+userNames:
+- system:serviceaccount:openshift-monitoring:sre-stuck-ebs-vols

--- a/deploy/050_service.yaml
+++ b/deploy/050_service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: stuck-ebs-vols
+  name: stuck-ebs-vols
+  namespace: openshift-monitoring
+spec:
+  ports:
+  - name: http-main
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    name: stuck-ebs-vols
+  sessionAffinity: None
+  type: ClusterIP

--- a/deploy/060_servicemonitor.yaml
+++ b/deploy/060_servicemonitor.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: stuck-ebs-vols
+  labels:
+    k8s-app: stuck-ebs-vols
+    name: stuck-ebs-vols
+spec:
+  endpoints:
+  - honorLabels: true
+    interval: 2m
+    port: http-main
+    scheme: http
+    scrapeTimeout: 2m
+    targetPort: 0
+  jobLabel: stuck-ebs-vols
+  namespaceSelector: {}
+  selector:
+    matchLabels:
+      name: stuck-ebs-vols

--- a/deploy/060_servicemonitor.yaml
+++ b/deploy/060_servicemonitor.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: stuck-ebs-vols
+  namespace: openshift-monitoring
   labels:
     k8s-app: stuck-ebs-vols
     name: stuck-ebs-vols

--- a/monitor/main.py
+++ b/monitor/main.py
@@ -1,0 +1,94 @@
+#!/usr/bin/python
+
+import openshift as oc
+import time
+import os
+import sys
+import re
+import logging
+
+from sets import Set
+from prometheus_client import start_http_server, Enum
+
+import boto3
+
+MONITOR_NAME = "sre-stuck-ebs-volume"
+PROJECT = "openshift-monitoring"
+VALID_STATES = [ "attaching", "attached", "detaching", "detached" ]
+
+#clusterid is included to better support future Prometheus federation.
+VOLUME_STATE = Enum('ebs_volume_state','EBS Volume state',["vol_name","clusterid"],
+                states = VALID_STATES)
+
+# A list (implemented as a Set) of all non-deleted volumes. 
+# After we get a list of all volume IDs from our running instances we will run
+# a query against the API for the volumes we know about and prune as needed.
+ACTIVE_VOLUMES = Set([])
+
+def normalize_prometheus_label(str):
+    """
+    Prometheus labels must match /[a-zA-Z_][a-zA-Z0-9_]*/ and so we should coerce our data to it.
+    Source: https://prometheus.io/docs/concepts/data_model/
+    Every invalid character will be made to be an underscore `_`.
+    """
+    return re.sub(r'[^[a-zA-Z_][a-zA-Z0-9_]*]',"_",str,0)
+
+def check_ebs_volumes_for_cluster(aws,clusterid):
+    """
+    Get all volumes from AWS, but only those in use by our cluster, then dump the metrics.
+    Note: It is important to filter by cluster id to prevent two clusters sharing
+    an account each paging for the same volume.
+    """
+
+    # get the instances that are in use by our cluster.
+    instances = aws.describe_instances(Filters=[
+        {
+            'Name': 'tag:clusterid', 'Values':[clusterid]
+        }
+    ])
+    normalized_clusterid = normalize_prometheus_label(clusterid)
+
+    # the volumes we've seen on this iteration. later, if we haven't seen a volume,
+    # we will purge it from VOLUME_STATES
+    seen_volumes = Set([])
+
+    # iterate through all the volumes
+    for reservation in instances["Reservations"]:
+        for instance in reservation["Instances"]:
+            for block_device_map in instance["BlockDeviceMappings"]:
+                if block_device_map["Ebs"]["Status"] not in VALID_STATES:
+                    logging.warning("clusterid='%s', vol_name='%s' in unknown state. Got state='%s'",clusterid,block_device_map["Ebs"]["VolumeId"],block_device_map["Ebs"]["Status"])
+                else:
+                    normalized_vol_id = normalize_prometheus_label(block_device_map["Ebs"]["VolumeId"])
+                    # Add the volume to the set
+                    ACTIVE_VOLUMES.add(block_device_map["Ebs"]["VolumeId"])
+                    seen_volumes.add(block_device_map["Ebs"]["VolumeId"])
+                    VOLUME_STATE.labels(normalized_vol_id,normalized_clusterid).state(block_device_map["Ebs"]["Status"])
+
+    for inactive_volume in ACTIVE_VOLUMES - seen_volumes:
+        logging.info("Removing vol_name='%s' for clusterid='%s' from Prometheus ",inactive_volume,clusterid)
+        VOLUME_STATE.remove(normalize_prometheus_label(inactive_volume),normalized_clusterid)
+        ACTIVE_VOLUMES.remove(inactive_volume)
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(name)s:%(message)s')
+    clusterid = ""
+    if "AWS_CONFIG_FILE" not in os.environ:
+        logging.error("Expected to have AWS_CONFIG_FILE set in the environment. Exiting...")
+        exit(1)
+    if "AWS_SHARED_CREDENTIALS_FILE" not in os.environ:
+        logging.error("Expected to have AWS_SHARED_CREDENTIALS_FILE set in the environment. Exiting...")
+        exit(1)
+    if "CLUSTERID" not in os.environ:
+        logging.error("Expected to have CLUSTERID in environment. Exiting")
+        exit(1)
+    clusterid = os.environ.get("CLUSTERID")
+    
+    aws = boto3.client('ec2')
+
+    logging.info('Starting up metrics endpoint')
+    # Start up the server to expose the metrics.
+    start_http_server(8080)
+    while True:
+        check_ebs_volumes_for_cluster(aws,clusterid)
+        time.sleep(60)

--- a/resources/040_deployment.yaml.tmpl
+++ b/resources/040_deployment.yaml.tmpl
@@ -1,0 +1,75 @@
+# need to define IMAGE_VERSION (eg, stable)
+# need to define CLUSTERID
+
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  name: stuck-ebs-vols
+  namespace: openshift-monitoring
+  labels:
+    name: stuck-ebs-vols
+spec:
+  replicas: 1
+  selector:
+    name: stuck-ebs-vols
+  template:
+    metadata:
+      name: sre-stuck-ebs-volume
+      labels:
+        name: stuck-ebs-vols
+    spec:
+      containers:
+      - name: "main"
+        command: ["/usr/bin/python", "/monitor/main.py"]
+        workingDir: /monitor
+        ports:
+        - containerPort: 8080
+          protocol: "TCP"
+        image: 'quay.io/jupierce/openshift-python-monitoring:$IMAGE_VERSION'
+        env:
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: /secrets/aws/credentials
+        - name: AWS_CONFIG_FILE
+          value: /secrets/aws/config
+        - name: PYTHONPATH
+          value: /openshift-python/packages:/support/packages
+        - name: CLUSTERID
+          value: $CLUSTERID
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 2
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 420
+          periodSeconds: 360
+          timeoutSeconds: 240
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 3
+          timeoutSeconds: 240
+        volumeMounts:
+        - name: monitor-volume
+          mountPath: /monitor
+          readOnly: true
+        - name: credentials-volume
+          mountPath: /secrets/aws
+          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      serviceAccountName: sre-stuck-ebs-vols
+      volumes:
+      # this is the source code
+      - name: monitor-volume
+        configMap:
+          name: stuck-ebs-vols-code
+      - name: credentials-volume
+        secret:
+          secretName: stuck-ebs-vols-credentials-volume
+  triggers:
+  - type: ConfigChange
+  strategy:
+    type: "Recreate"
+  paused: false

--- a/resources/secrets-config.tmpl
+++ b/resources/secrets-config.tmpl
@@ -1,0 +1,2 @@
+[default]
+region=$AWS_REGION

--- a/resources/secrets-credentials.tmpl
+++ b/resources/secrets-credentials.tmpl
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id=$AWS_ACCESS_KEY_ID
+aws_secret_access_key=$AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
This is the first of the exporters to relocate and has been reworked and represents a major change from the previous iteration. Whereas the previous iteration had a Python script to install and create objects in-cluster, this approach lets something else do that (eg SREP-924 and/or SREP-815, or something else) with the YAML manifest files required to install this exporter.

Several variables are needed at deploy time (cluster ID, AWS credentials/region) before the manifests can be ready to `oc apply`. They are provided to the `Makefile` which is responsible for rendering the those "dynamic" manifests.

If this pattern seems ok, I can follow it for the other exporters.
