### PR TITLE
Move to use origin-cli-based image w/ cred minter & ebs-iops-reporter Makefile format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Rendered templates
-deploy/025_sourcecode.yaml
-deploy/040_deployment.yaml
+deploy/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Rendered templates
 deploy/025_sourcecode.yaml
-deploy/030_secrets.yaml
 deploy/040_deployment.yaml
 
 # Byte-compiled / optimized / DLL files

--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,71 @@
 SHELL := /bin/bash
+include functions.mk
+
+# Name of the exporter
+EXPORTER_NAME := stuck-ebs-vols
+# valid: deployment or daemonset
+# currently unused
+EXPORTER_TYPE := deployment
 
 # All of the source files which compose the monitor. 
 # Important note: No directory structure will be maintained
 SOURCEFILES ?= monitor/main.py monitor/start.sh
 
-INIT_IMAGE_VERSION ?= 1903.0.0
+# What to prefix the name of resources with?
+NAME_PREFIX ?= sre-
+SOURCE_CONFIGMAP_SUFFIX ?= -code
+CREDENITALS_SUFFIX ?= -aws-credentials
+
+MAIN_IMAGE_URI ?= quay.io/jupierce/openshift-python-monitoring
 IMAGE_VERSION ?= stable
+INIT_IMAGE_URI ?= quay.io/lseelye/yq-kubectl
+INIT_IMAGE_VERSION ?= 1903.0.0
 
-RESOURCELIST := servicemonitor/stuck-ebs-vols service/stuck-ebs-vols \
-	deployment/stuck-ebs-vols secret/stuck-ebs-vols-credentials-volume \
-	configmap/stuck-ebs-vols-code rolebinding/sre-stuck-ebs-vols \
-	serviceaccount/sre-stuck-ebs-vols clusterrole/sre-allow-read-cluster-setup \
-	rolebinding/sre-stuck-ebs-vols-read-cluster-setup CredentialsRequest/stuck-ebs-vols-aws-credentials \
-	secrets/stuck-ebs-vols-aws-credentials
+# Generate variables
 
-all: deploy/025_sourcecode.yaml deploy/040_deployment.yaml
+MAIN_IMAGE ?= $(MAIN_IMAGE_URI):$(IMAGE_VERSION)
+INIT_IMAGE ?= $(INIT_IMAGE_URI):$(INIT_IMAGE_VERSION)
+
+PREFIXED_NAME ?= $(NAME_PREFIX)$(EXPORTER_NAME)
+
+AWS_CREDENTIALS_SECRET_NAME ?= $(PREFIXED_NAME)$(CREDENITALS_SUFFIX)
+SOURCE_CONFIGMAP_NAME ?= $(PREFIXED_NAME)$(SOURCE_CONFIGMAP_SUFFIX)
+SERVICEACCOUNT_NAME ?= $(PREFIXED_NAME)
+
+RESOURCELIST := servicemonitor/$(PREFIXED_NAME) service/$(PREFIXED_NAME) \
+	deploymentconfig/$(PREFIXED_NAME) secret/$(AWS_CREDENTIALS_SECRET_NAME) \
+	configmap/$(SOURCE_CONFIGMAP_NAME) rolebinding/$(PREFIXED_NAME) \
+	serviceaccount/$(SERVICEACCOUNT_NAME) clusterrole/sre-allow-read-cluster-setup \
+  CredentialsRequest/$(AWS_CREDENTIALS_SECRET_NAME)
+
+
+all: deploy/010_serviceaccount-rolebinding.yaml deploy/020-awscredentials-request.yaml deploy/025_sourcecode.yaml deploy/040_deployment.yaml deploy/050_service.yaml deploy/060_servicemonitor.yaml
+
+deploy/020-awscredentials-request.yaml: resources/020-awscredentials-request.yaml.tmpl
+	@$(call generate_file,020-awscredentials-request)
+
+deploy/010_serviceaccount-rolebinding.yaml: resources/010_serviceaccount-rolebinding.yaml.tmpl
+	@$(call generate_file,010_serviceaccount-rolebinding)
 
 deploy/025_sourcecode.yaml: $(SOURCEFILES)
 	@for sfile in $(SOURCEFILES); do \
 		files="--from-file=$$sfile $$files" ; \
 	done ; \
-	kubectl -n openshift-monitoring create configmap stuck-ebs-vols-code --dry-run=true -o yaml $$files 1> deploy/025_sourcecode.yaml
+	kubectl -n openshift-monitoring create configmap $(SOURCE_CONFIGMAP_NAME) --dry-run=true -o yaml $$files 1> deploy/025_sourcecode.yaml
 
 deploy/040_deployment.yaml: resources/040_deployment.yaml.tmpl
-	@sed \
-		-e "s/\$$IMAGE_VERSION/$(IMAGE_VERSION)/g" \
-		-e "s/\$$INIT_IMAGE_VERSION/$(INIT_IMAGE_VERSION)/g" \
-	resources/040_deployment.yaml.tmpl 1> deploy/040_deployment.yaml
+	@$(call generate_file,040_deployment)
+
+deploy/050_service.yaml: resources/050_service.yaml.tmpl
+	@$(call generate_file,050_service)
+
+deploy/060_servicemonitor.yaml: resources/060_servicemonitor.yaml.tmpl
+	@$(call generate_file,060_servicemonitor)
+
 
 .PHONY: clean
 clean:
-	rm -f deploy/025_sourcecode.yaml deploy/040_deployment.yaml
+	rm -f deploy/*.yaml
 
 .PHONY: filelist
 filelist: all
@@ -39,3 +74,7 @@ filelist: all
 .PHONE: resourcelist
 resourcelist:
 	@echo $(RESOURCELIST)
+
+.PHONY: vardump
+vardump:
+	@echo $(SOURCE_CONFIGMAP_NAME)

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ RESOURCELIST := servicemonitor/$(PREFIXED_NAME) service/$(PREFIXED_NAME) \
 	deploymentconfig/$(PREFIXED_NAME) secret/$(AWS_CREDENTIALS_SECRET_NAME) \
 	configmap/$(SOURCE_CONFIGMAP_NAME) rolebinding/$(PREFIXED_NAME) \
 	serviceaccount/$(SERVICEACCOUNT_NAME) clusterrole/sre-allow-read-cluster-setup \
-  CredentialsRequest/$(AWS_CREDENTIALS_SECRET_NAME)
+	CredentialsRequest/$(AWS_CREDENTIALS_SECRET_NAME)
 
 
 all: deploy/010_serviceaccount-rolebinding.yaml deploy/020-awscredentials-request.yaml deploy/025_sourcecode.yaml deploy/040_deployment.yaml deploy/050_service.yaml deploy/060_servicemonitor.yaml

--- a/Makefile
+++ b/Makefile
@@ -2,70 +2,35 @@ SHELL := /bin/bash
 
 # All of the source files which compose the monitor. 
 # Important note: No directory structure will be maintained
-SOURCEFILES ?= monitor/main.py
+SOURCEFILES ?= monitor/main.py monitor/start.sh
 
+INIT_IMAGE_VERSION ?= 1903.0.0
 IMAGE_VERSION ?= stable
-RESOURCELIST := servicemonitor/stuck-ebs-vols service/stuck-ebs-vols deployment/stuck-ebs-vols secret/stuck-ebs-vols-credentials-volume configmap/stuck-ebs-vols-code rolebinding/sre-stuck-ebs-vols serviceaccount/sre-stuck-ebs-vols
 
-all: deploy/025_sourcecode.yaml deploy/030_secrets.yaml deploy/040_deployment.yaml
+RESOURCELIST := servicemonitor/stuck-ebs-vols service/stuck-ebs-vols \
+	deployment/stuck-ebs-vols secret/stuck-ebs-vols-credentials-volume \
+	configmap/stuck-ebs-vols-code rolebinding/sre-stuck-ebs-vols \
+	serviceaccount/sre-stuck-ebs-vols clusterrole/sre-allow-read-cluster-setup \
+	rolebinding/sre-stuck-ebs-vols-read-cluster-setup CredentialsRequest/stuck-ebs-vols-aws-credentials \
+	secrets/stuck-ebs-vols-aws-credentials
 
-.PHONY: check-env
-check-env:
-ifndef CLUSTERID
-	$(error Please set CLUSTERID)
-endif
-ifndef AWS_REGION
-	$(error Please set AWS_REGION)
-endif
-ifndef AWS_SECRET_ACCESS_KEY
-	$(error Please set AWS_SECRET_ACCESS_KEY)
-endif
-ifndef AWS_ACCESS_KEY_ID
-	$(error Please set AWS_ACCESS_KEY_ID)
-endif
+all: deploy/025_sourcecode.yaml deploy/040_deployment.yaml
 
 deploy/025_sourcecode.yaml: $(SOURCEFILES)
-	@echo "Creating $(@)" ; \
-	for sfile in $(SOURCEFILES); do \
+	@for sfile in $(SOURCEFILES); do \
 		files="--from-file=$$sfile $$files" ; \
 	done ; \
 	kubectl -n openshift-monitoring create configmap stuck-ebs-vols-code --dry-run=true -o yaml $$files 1> deploy/025_sourcecode.yaml
 
-deploy/040_deployment.yaml: check-env
-	@echo "Creating $(@)" ; \
-	sed \
+deploy/040_deployment.yaml: resources/040_deployment.yaml.tmpl
+	@sed \
 		-e "s/\$$IMAGE_VERSION/$(IMAGE_VERSION)/g" \
-		-e "s/\$$CLUSTERID/$$CLUSTERID/g" \
+		-e "s/\$$INIT_IMAGE_VERSION/$(INIT_IMAGE_VERSION)/g" \
 	resources/040_deployment.yaml.tmpl 1> deploy/040_deployment.yaml
-
-deploy/030_secrets.yaml: check-env
-	@echo "Creating $(@)" ; \
-	umask 077 ; \
-	tmpdir=$(shell mktemp -d $(self)) ; \
-	if [[ ! -d $$tmpdir ]]; then \
-		echo "Not able to create temp dir for secrets. Giving up" ;\
-		exit 1 ;\
-	fi ;\
-	echo "  Temporary dir=$$tmpdir" ; \
-	sed \
-		-e "s/\$$AWS_ACCESS_KEY_ID/$$AWS_ACCESS_KEY_ID/g" \
-		-e "s/\$$AWS_SECRET_ACCESS_KEY/$$AWS_SECRET_ACCESS_KEY/g" \
-	resources/secrets-credentials.tmpl 1> $$tmpdir/credentials ; \
-	sed \
-		-e "s/\$$AWS_REGION/$$AWS_REGION/g" \
-	resources/secrets-config.tmpl 1> $$tmpdir/config ; \
-	kubectl \
-		-n openshift-monitoring \
-		create secret generic stuck-ebs-vols-credentials-volume \
-		--dry-run=true -o yaml \
-		--from-file=$$tmpdir/credentials --from-file=$$tmpdir/config \
-		1> deploy/030_secrets.yaml ; \
-	echo "  Cleaning temp dir ($$tmpdir)" ; \
-	rm -rf $$tmpdir
 
 .PHONY: clean
 clean:
-	rm -f deploy/025_sourcecode.yaml deploy/030_secrets.yaml deploy/040_deployment.yaml
+	rm -f deploy/025_sourcecode.yaml deploy/040_deployment.yaml
 
 .PHONY: filelist
 filelist: all

--- a/deploy/010_serviceaccount-rolebinding.yaml
+++ b/deploy/010_serviceaccount-rolebinding.yaml
@@ -5,16 +5,40 @@ metadata:
   name: sre-stuck-ebs-vols
   namespace: openshift-monitoring
 ---
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: sre-stuck-ebs-vols
   namespace: openshift-monitoring
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
   name: edit
 subjects:
 - kind: ServiceAccount
   name: sre-stuck-ebs-vols
   namespace: openshift-monitoring
-userNames:
-- system:serviceaccount:openshift-monitoring:sre-stuck-ebs-vols
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sre-allow-read-machine-info
+rules:
+- apiGroups: ["machine.openshift.io"]
+  resources: ["machines"]
+  verbs: ["get", "list"]
+---
+kind: RoleBinding
+groupNames: null
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sre-stuck-ebs-vols-read-machine-info
+  namespace: openshift-machine-api
+subjects:
+- kind: ServiceAccount
+  name: sre-stuck-ebs-vols
+  namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sre-allow-read-machine-info

--- a/deploy/020-awscredentials-request.yaml
+++ b/deploy/020-awscredentials-request.yaml
@@ -1,0 +1,17 @@
+apiVersion: cloudcredential.openshift.io/v1beta1
+kind: CredentialsRequest
+metadata:
+  name: stuck-ebs-vols-aws-credentials
+  namespace: openshift-monitoring
+spec:
+  secretRef:
+    name: stuck-ebs-vols-aws-credentials
+    namespace: openshift-monitoring
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1beta1
+    kind: AWSProviderSpec
+    statementEntries:
+    - effect: Allow
+      action:
+      - ec2:DescribeInstances
+      resource: "*"

--- a/functions.mk
+++ b/functions.mk
@@ -1,0 +1,12 @@
+# Be sure to add new variables to this function
+define generate_file
+	sed \
+		-e "s!\$$EXPORTER_NAME!$(EXPORTER_NAME)!g" \
+		-e "s!\$$PREFIXED_NAME!$(PREFIXED_NAME)!g" \
+		-e "s!\$$MAIN_IMAGE!$(MAIN_IMAGE)!g" \
+		-e "s!\$$INIT_IMAGE!$(INIT_IMAGE)!g" \
+		-e "s!\$$SERVICEACCOUNT_NAME!$(SERVICEACCOUNT_NAME)!g" \
+		-e "s!\$$SOURCE_CONFIGMAP_NAME!$(SOURCE_CONFIGMAP_NAME)!g" \
+		-e "s!\$$AWS_CREDENTIALS_SECRET_NAME!$(AWS_CREDENTIALS_SECRET_NAME)!g" \
+	resources/$(1).yaml.tmpl 1> deploy/$(1).yaml
+endef

--- a/monitor/start.sh
+++ b/monitor/start.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -o allexport
+
+if [[ -d /config && -d /config/env ]]; then
+  source /config/env/*
+fi
+
+exec /usr/bin/python /monitor/main.py "$@"

--- a/resources/010_serviceaccount-rolebinding.yaml.tmpl
+++ b/resources/010_serviceaccount-rolebinding.yaml.tmpl
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: sre-stuck-ebs-vols
+  name: $SERVICEACCOUNT_NAME
   namespace: openshift-monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: sre-stuck-ebs-vols
+  name: $SERVICEACCOUNT_NAME
   namespace: openshift-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -16,7 +16,7 @@ roleRef:
   name: edit
 subjects:
 - kind: ServiceAccount
-  name: sre-stuck-ebs-vols
+  name: $SERVICEACCOUNT_NAME
   namespace: openshift-monitoring
 ---
 kind: ClusterRole
@@ -29,14 +29,13 @@ rules:
   verbs: ["get", "list"]
 ---
 kind: RoleBinding
-groupNames: null
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: sre-stuck-ebs-vols-read-machine-info
+  name: $SERVICEACCOUNT_NAME-read-machine-info
   namespace: openshift-machine-api
 subjects:
 - kind: ServiceAccount
-  name: sre-stuck-ebs-vols
+  name: $SERVICEACCOUNT_NAME
   namespace: openshift-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/resources/020-awscredentials-request.yaml.tmpl
+++ b/resources/020-awscredentials-request.yaml.tmpl
@@ -1,11 +1,11 @@
 apiVersion: cloudcredential.openshift.io/v1beta1
 kind: CredentialsRequest
 metadata:
-  name: stuck-ebs-vols-aws-credentials
+  name: $AWS_CREDENTIALS_SECRET_NAME
   namespace: openshift-monitoring
 spec:
   secretRef:
-    name: stuck-ebs-vols-aws-credentials
+    name: $AWS_CREDENTIALS_SECRET_NAME
     namespace: openshift-monitoring
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1beta1

--- a/resources/040_deployment.yaml.tmpl
+++ b/resources/040_deployment.yaml.tmpl
@@ -1,7 +1,4 @@
-# need to define IMAGE_VERSION (eg, stable)
-# need to define CLUSTERID
-
-apiVersion: v1
+apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
   name: stuck-ebs-vols
@@ -18,9 +15,21 @@ spec:
       labels:
         name: stuck-ebs-vols
     spec:
+      initContainers:
+      - name: setupcreds
+        image: quay.io/lseelye/yq-kubectl:$INIT_IMAGE_VERSION
+        command: [ "/usr/local/bin/init.py", "-r", "/secrets/aws/config.ini", "-a", "/rawsecrets/aws_access_key_id", "-A", "/rawsecrets/aws_secret_access_key", "-o", "/secrets/aws/credentials.ini", "-c", "/config/env/CLUSTERID" ]
+        volumeMounts:
+        - name: awsrawcreds
+          mountPath: /rawsecrets
+          readOnly: true
+        - name: secrets
+          mountPath: /secrets
+        - name: envfiles
+          mountPath: /config
       containers:
       - name: "main"
-        command: ["/usr/bin/python", "/monitor/main.py"]
+        command: [ "/bin/sh", "/monitor/start.sh" ]
         workingDir: /monitor
         ports:
         - containerPort: 8080
@@ -28,13 +37,11 @@ spec:
         image: 'quay.io/jupierce/openshift-python-monitoring:$IMAGE_VERSION'
         env:
         - name: AWS_SHARED_CREDENTIALS_FILE
-          value: /secrets/aws/credentials
+          value: /secrets/aws/credentials.ini
         - name: AWS_CONFIG_FILE
-          value: /secrets/aws/config
+          value: /secrets/aws/config.ini
         - name: PYTHONPATH
           value: /openshift-python/packages:/support/packages
-        - name: CLUSTERID
-          value: $CLUSTERID
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 2
@@ -54,8 +61,11 @@ spec:
         - name: monitor-volume
           mountPath: /monitor
           readOnly: true
-        - name: credentials-volume
-          mountPath: /secrets/aws
+        - name: envfiles
+          mountPath: /config
+          readOnly: true
+        - name: secrets
+          mountPath: /secrets
           readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
@@ -65,9 +75,13 @@ spec:
       - name: monitor-volume
         configMap:
           name: stuck-ebs-vols-code
-      - name: credentials-volume
+      - name: awsrawcreds
         secret:
-          secretName: stuck-ebs-vols-credentials-volume
+          secretName: stuck-ebs-vols-aws-credentials
+      - name: secrets
+        emptyDir: {}
+      - name: envfiles
+        emptyDir: {}
   triggers:
   - type: ConfigChange
   strategy:

--- a/resources/040_deployment.yaml.tmpl
+++ b/resources/040_deployment.yaml.tmpl
@@ -1,23 +1,23 @@
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
 metadata:
-  name: stuck-ebs-vols
+  name: $PREFIXED_NAME
   namespace: openshift-monitoring
   labels:
-    name: stuck-ebs-vols
+    name: $PREFIXED_NAME
 spec:
   replicas: 1
   selector:
-    name: stuck-ebs-vols
+    name: $PREFIXED_NAME
   template:
     metadata:
-      name: sre-stuck-ebs-volume
+      name: $PREFIXED_NAME
       labels:
-        name: stuck-ebs-vols
+        name: $PREFIXED_NAME
     spec:
       initContainers:
       - name: setupcreds
-        image: quay.io/lseelye/yq-kubectl:$INIT_IMAGE_VERSION
+        image: $INIT_IMAGE
         command: [ "/usr/local/bin/init.py", "-r", "/secrets/aws/config.ini", "-a", "/rawsecrets/aws_access_key_id", "-A", "/rawsecrets/aws_secret_access_key", "-o", "/secrets/aws/credentials.ini", "-c", "/config/env/CLUSTERID" ]
         volumeMounts:
         - name: awsrawcreds
@@ -34,7 +34,7 @@ spec:
         ports:
         - containerPort: 8080
           protocol: "TCP"
-        image: 'quay.io/jupierce/openshift-python-monitoring:$IMAGE_VERSION'
+        image: $MAIN_IMAGE
         env:
         - name: AWS_SHARED_CREDENTIALS_FILE
           value: /secrets/aws/credentials.ini
@@ -69,19 +69,18 @@ spec:
           readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
-      serviceAccountName: sre-stuck-ebs-vols
+      serviceAccountName: $SERVICEACCOUNT_NAME
       volumes:
-      # this is the source code
-      - name: monitor-volume
-        configMap:
-          name: stuck-ebs-vols-code
       - name: awsrawcreds
         secret:
-          secretName: stuck-ebs-vols-aws-credentials
+          secretName: $AWS_CREDENTIALS_SECRET_NAME
       - name: secrets
         emptyDir: {}
       - name: envfiles
         emptyDir: {}
+      - name: monitor-volume
+        configMap:
+          name: $SOURCE_CONFIGMAP_NAME
   triggers:
   - type: ConfigChange
   strategy:

--- a/resources/050_service.yaml.tmpl
+++ b/resources/050_service.yaml.tmpl
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: stuck-ebs-vols
-  name: stuck-ebs-vols
+    name: $PREFIXED_NAME
+  name: $PREFIXED_NAME
   namespace: openshift-monitoring
 spec:
   ports:
@@ -12,6 +12,6 @@ spec:
     protocol: TCP
     targetPort: 8080
   selector:
-    name: stuck-ebs-vols
+    name: $PREFIXED_NAME
   sessionAffinity: None
   type: ClusterIP

--- a/resources/060_servicemonitor.yaml.tmpl
+++ b/resources/060_servicemonitor.yaml.tmpl
@@ -1,11 +1,11 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: stuck-ebs-vols
+  name: $PREFIXED_NAME
   namespace: openshift-monitoring
   labels:
-    k8s-app: stuck-ebs-vols
-    name: stuck-ebs-vols
+    k8s-app: $PREFIXED_NAME
+    name: $PREFIXED_NAME
 spec:
   endpoints:
   - honorLabels: true
@@ -14,8 +14,8 @@ spec:
     scheme: http
     scrapeTimeout: 2m
     targetPort: 0
-  jobLabel: stuck-ebs-vols
+  jobLabel: $PREFIXED_NAME
   namespaceSelector: {}
   selector:
     matchLabels:
-      name: stuck-ebs-vols
+      name: $PREFIXED_NAME

--- a/resources/secrets-config.tmpl
+++ b/resources/secrets-config.tmpl
@@ -1,2 +1,0 @@
-[default]
-region=$AWS_REGION

--- a/resources/secrets-credentials.tmpl
+++ b/resources/secrets-credentials.tmpl
@@ -1,3 +1,0 @@
-[default]
-aws_access_key_id=$AWS_ACCESS_KEY_ID
-aws_secret_access_key=$AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
Changes:

* Change primary rolebinding away from `authorization.openshift.io/v1` to `rbac.authorization.k8s.io/v1`
* Switch to origin-cli init container and Amazon credential minter (See https://github.com/lisa/docker-yq-kubectl/issues/5 and https://github.com/lisa/docker-yq-kubectl/pull/1)
* Adopt Makefile from https://github.com/openshift/managed-prometheus-exporter-ebs-iops-reporter/pull/1


Signed-off-by: Lisa Seelye <lseelye@redhat.com>