### PR TITLE
make shebang more portable

### DIFF
--- a/scripts/generate_syncset.py
+++ b/scripts/generate_syncset.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import os
 import sys
 import yaml 


### PR DESCRIPTION
using pyenv, `/usr/bin/python` is not the binary I want to execute. Using `/usr/bin/env` should make the script portable to other systems.