### PR TITLE
Update SelectorSyncSet

### DIFF
--- a/hack/00-osd-managed-prometheus-exporter-stuck-ebs-vols.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-prometheus-exporter-stuck-ebs-vols.selectorsyncset.yaml.tmpl
@@ -8,14 +8,15 @@ objects:
   metadata:
     generation: 1
     labels:
-      managed.openshift.io/gitHash: 47f7566
+      managed.openshift.io/gitHash: e2885eb
       managed.openshift.io/osd: 'true'
     name: osd-managed-prometheus-exporter-stuck-ebs-vols
   spec:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: 'true'
-    resourceApplyMode: sync
+        hive.openshift.io/cluster-platform: aws
+    resourceApplyMode: Sync
     resources:
     - apiVersion: v1
       kind: ServiceAccount

--- a/scripts/templates/selectorsyncset.yaml
+++ b/scripts/templates/selectorsyncset.yaml
@@ -16,4 +16,5 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: "true"
+        hive.openshift.io/cluster-platform: "aws"
     resourceApplyMode: Sync

--- a/scripts/templates/selectorsyncset.yaml
+++ b/scripts/templates/selectorsyncset.yaml
@@ -16,4 +16,4 @@ objects:
     clusterDeploymentSelector:
       matchLabels:
         api.openshift.com/managed: "true"
-    resourceApplyMode: sync
+    resourceApplyMode: Sync


### PR DESCRIPTION
This does the following:
- Changes the resourceApplyMode to `Sync`
- Adds a label so that this only deploys to AWS, as it's EBS specific