### PR TITLE
OSD-8637 Enable exporter to trust user-ca-bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ RESOURCELIST := servicemonitor/$(PREFIXED_NAME) service/$(PREFIXED_NAME) \
 	CredentialsRequest/$(AWS_CREDENTIALS_SECRET_NAME)
 
 
-all: deploy/010_serviceaccount-rolebinding.yaml deploy/020-awscredentials-request.yaml deploy/025_sourcecode.yaml deploy/040_deployment.yaml deploy/050_service.yaml deploy/060_servicemonitor.yaml generate-syncset
+all: deploy/010_serviceaccount-rolebinding.yaml deploy/020-awscredentials-request.yaml deploy/025_sourcecode.yaml deploy/030_ca-configmap.yaml deploy/040_deployment.yaml deploy/050_service.yaml deploy/060_servicemonitor.yaml generate-syncset
 
 deploy/020-awscredentials-request.yaml: resources/020-awscredentials-request.yaml.tmpl
 	@$(call generate_file,020-awscredentials-request)
@@ -67,6 +67,9 @@ deploy/025_sourcecode.yaml: $(SOURCEFILES)
 		files="--from-file=$$sfile $$files" ; \
 	done ; \
 	oc -n openshift-monitoring create configmap $(SOURCE_CONFIGMAP_NAME) --dry-run=client -o yaml $$files 1> $@
+
+deploy/030_ca-configmap.yaml: resources/030_ca-configmap.yaml.tmpl
+	@$(call generate_file,030_ca-configmap)
 
 deploy/040_deployment.yaml: resources/040_deployment.yaml.tmpl
 	@$(call generate_file,040_deployment)

--- a/hack/00-osd-managed-prometheus-exporter-stuck-ebs-vols.selectorsyncset.yaml.tmpl
+++ b/hack/00-osd-managed-prometheus-exporter-stuck-ebs-vols.selectorsyncset.yaml.tmpl
@@ -8,7 +8,7 @@ objects:
   metadata:
     generation: 1
     labels:
-      managed.openshift.io/gitHash: e746757
+      managed.openshift.io/gitHash: d0211c4
       managed.openshift.io/osd: 'true'
     name: osd-managed-prometheus-exporter-stuck-ebs-vols
   spec:
@@ -148,6 +148,13 @@ objects:
         creationTimestamp: null
         name: sre-stuck-ebs-vols-code
         namespace: openshift-monitoring
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        labels:
+          config.openshift.io/inject-trusted-cabundle: 'true'
+        name: sre-stuck-ebs-vols-trusted-ca-bundle
+        namespace: openshift-monitoring
     - apiVersion: apps.openshift.io/v1
       kind: DeploymentConfig
       metadata:
@@ -217,6 +224,9 @@ objects:
               - mountPath: /secrets
                 name: secrets
                 readOnly: true
+              - mountPath: /etc/pki/ca-trust/extracted/pem
+                name: trusted-ca-bundle
+                readOnly: true
               workingDir: /monitor
             dnsPolicy: ClusterFirst
             initContainers:
@@ -242,6 +252,9 @@ objects:
                 name: secrets
               - mountPath: /config
                 name: envfiles
+              - mountPath: /etc/pki/ca-trust/extracted/pem
+                name: trusted-ca-bundle
+                readOnly: true
             restartPolicy: Always
             serviceAccountName: sre-stuck-ebs-vols
             tolerations:
@@ -259,6 +272,13 @@ objects:
             - configMap:
                 name: sre-stuck-ebs-vols-code
               name: monitor-volume
+            - configMap:
+                defaultMode: 420
+                items:
+                - key: ca-bundle.crt
+                  path: tls-ca-bundle.pem
+                name: sre-stuck-ebs-vols-trusted-ca-bundle
+              name: trusted-ca-bundle
         triggers:
         - type: ConfigChange
     - apiVersion: v1

--- a/resources/030_ca-configmap.yaml.tmpl
+++ b/resources/030_ca-configmap.yaml.tmpl
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-monitoring
+  name: $PREFIXED_NAME-trusted-ca-bundle
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/resources/040_deployment.yaml.tmpl
+++ b/resources/040_deployment.yaml.tmpl
@@ -27,6 +27,9 @@ spec:
           mountPath: /secrets
         - name: envfiles
           mountPath: /config
+        - mountPath: /etc/pki/ca-trust/extracted/pem
+          name: trusted-ca-bundle
+          readOnly: true
       containers:
       - name: "main"
         command: [ "/bin/sh", "/monitor/start.sh" ]
@@ -67,6 +70,9 @@ spec:
         - name: secrets
           mountPath: /secrets
           readOnly: true
+        - mountPath: /etc/pki/ca-trust/extracted/pem
+          name: trusted-ca-bundle
+          readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       serviceAccountName: $SERVICEACCOUNT_NAME
@@ -93,6 +99,13 @@ spec:
       - name: monitor-volume
         configMap:
           name: $SOURCE_CONFIGMAP_NAME
+      - name: trusted-ca-bundle
+        configMap:
+          defaultMode: 420
+          items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem
+          name: $PREFIXED_NAME-trusted-ca-bundle
   triggers:
   - type: ConfigChange
   strategy:


### PR DESCRIPTION
### What type of PR is this?

Feature

### What this PR does / why we need it?

This PR adds a new `trusted-ca-bundle` ConfigMap for the exporter which will contain the system CA certs used to authenticate HTTPS connections. [0]

The ConfigMap contains the `config.openshift.io/inject-trusted-cabundle` label so that the user-supplied CA bundle is injected into it.

The ConfigMap is mounted into the container in the `/etc/pki/ca-trust/extracted/pem` location such that no other work is required to have the application use these CA for verifying server cert authenticity.

This is an approach which aligns with other cluster operators including the console and insights operators. 

[0] https://docs.openshift.com/container-platform/4.9/networking/configuring-a-custom-pki.html

### Which Jira/Github issue(s) this PR fixes?

[OSD-8637](https://issues.redhat.com/browse/OSD-8637)

### Special notes for your reviewer:

This change has been successfully tested on a cluster using a transparent forward proxy to ensure that it could successfully communicate to `*.amazonaws.com`.

### Pre-checks (if applicable):
- [X] Tested latest changes against a cluster
- [X] Ran `make generate` command locally to validate code changes
- [ ] Included documentation changes with PR
